### PR TITLE
Automatic releases with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,9 @@ script:
   - npm run test
   - npm run e2e
   - npm run build
+deploy:
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
#2 
This should create a new release every time a new build is made. The GITHUB_OATH_TOKEN must be configured from Travis to successfully run it.

The changes should work but I was unable to test it because you seem to have a couple of errors in your code and fixing those are not part of the scope of the issue.